### PR TITLE
Adjusts #round_price to round up to x.17 rather than down to x-1.97

### DIFF
--- a/index.html
+++ b/index.html
@@ -138,8 +138,8 @@
 
         function roundPrice(num) {
             console.log(num);
-            let x = Math.floor(Number(num)) - 1;
-            return x.toString()+'.97';
+            let x = num.slice(0, -2);
+            return x.toString()+'17';
         }
 
         function clearance(price) {


### PR DESCRIPTION
The price calculator now always rounds up to the markdown price rather than rounding down in edge cases.